### PR TITLE
Changed the name of the repository in the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "php-ews/php-ews",
+  "name": "facilioo/php-ews",
   "description": "Library for communicating with Exchange Web Services.",
   "homepage": "http://jamesarmes.com/php-ews/",
   "license": "MIT",


### PR DESCRIPTION
To be able to use the repository from the Github sources, we need to get a proper name in the composer.json